### PR TITLE
Updated All Outlines list display and sort order

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,9 @@
 require "./source/helpers/view_helpers"
 require "./source/helpers/comment_helpers"
+require "./source/helpers/outline_list_helpers"
 helpers ViewHelpers
 helpers CommentHelpers
+helpers OutlineListHelpers
 
 # Compass
 ###

--- a/source/all.html.haml
+++ b/source/all.html.haml
@@ -4,5 +4,5 @@
       %h1 All Outlines
 
       %ul
-      - sitemap.resources[0..100].each do |resource|
-        %li= link_to resource.path, resource.path
+      - outline_list(sitemap.resources).first(100).each do |outline|
+        %li= link_to outline_name(outline.path), outline.path

--- a/source/helpers/outline_list_helpers.rb
+++ b/source/helpers/outline_list_helpers.rb
@@ -1,0 +1,11 @@
+module OutlineListHelpers
+  def outline_list(resources)
+    resources.select {|r| r.data.layout == 'outline'}\
+             .sort_by {|o| outline_name(o.path)}\
+             .reverse
+  end
+
+  def outline_name(path)
+    path.split('/').last.split('.').first
+  end
+end


### PR DESCRIPTION
I'll be a student in the upcoming 1410 class and have been reviewing the class outline archives. The current list was kind of hard to navigate (unordered, non-outlines included, link naming) so I thought I'd take a shot at updating. 
- Created a new helpers module (OutlineListHelpers) with methods for 1) pulling a sorted list of only site resources with an 'outline' layout, and 2) parsing the name from the file path
- Passed this revised outline list and updated naming convention to li loop in all.html.haml (original capped records at 101, update caps at 100)

Updated li display:
![screen shot 2014-10-14 at 11 12 59 pm](https://cloud.githubusercontent.com/assets/3827810/4640458/9ead94fa-5421-11e4-8a22-f33bc94cc1e7.png)
